### PR TITLE
Move the submission checklist here

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,0 +1,8 @@
+---
+name: Task or idea
+about: A task that should be done or idea
+title: ''
+labels: ''
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/paper-submission.md
+++ b/.github/ISSUE_TEMPLATE/paper-submission.md
@@ -1,0 +1,35 @@
+---
+name: Submit the paper
+about: Checklist for submitting the paper to a journal and preprint server
+title: Submit the paper to a journal and EarthArXiv
+labels: ''
+assignees: ''
+
+---
+
+## Information
+
+<!--
+Keep the DOIs, important URLs and more so they can be easily found if needed.
+Remember that this issue will be publicly available, don't put sensitive data,
+private links or tokens.
+-->
+
+- Journal name:
+- Journal guidelines for authors:
+- Supplementary material DOI (from figshare/Zenodo):
+
+## Checklist
+
+- [ ] Do one final proof-read of the whole paper, double-checking format, figures, and equations.
+- [ ] Reserve a DOI on [figshare](https://figshare.com/) or [Zenodo](https://zenodo.org/) for the supplementary material (zip archive of this repository). Paste the DOI at the top of this issue.
+- [ ] Add the _supplementary DOI_ to the manuscript in a "Data and code availability" section.
+- [ ] Submit the preprint to [EarthArXiv](https://eartharxiv.org/).
+- [ ] Add the _preprint DOI_ and _supplementary DOI_ to the `README.md` file.
+- [ ] Make a release on GitHub with the `submitted` tag.
+- [ ] Upload the `.zip` archive of the repository (the one with the full history, not the release archive) to figshare or Zenodo and publish it.
+- [ ] Make the GitHub repository public (if it isn't already).
+- [ ] Add the preprint to the CompGeoLab (and your personal) website.
+- [ ] Share the preprint DOI link on social media (use a nice figure or make a graphical abstract).
+- [ ] Make a cover letter for the journal. Include a short summary, suggested reviewers, and contributions by student authors.
+- [ ] Submit the paper to the journal.


### PR DESCRIPTION
It was living in the organization `.github` repo but we don't want this
in every repository, just in the papers. Move it and the general issue
template here instead. Did some minor updates to the checklist.